### PR TITLE
Silence warnings about empty if/else bodies in release builds.

### DIFF
--- a/PadWalker.xs
+++ b/PadWalker.xs
@@ -14,7 +14,7 @@
 #ifdef PADWALKER_DEBUGGING
 # define debug_print(x) printf x
 #else
-# define debug_print(x)
+# define debug_print(x) do {} while (0)
 #endif
 
 /* For debugging */


### PR DESCRIPTION
As debug_print expands to nothing unless PADWALKER_DEBUGGING is
set gcc will warn about "suggest braces around empty body in an
‘if’ statement" (same for ´else´) if ´-Wempty-body´ is used.
And that one is implied by ´-W´.

By defining the macro to a no-op statement we provide a
suitable replacement rather than nothing. A common technique
also used for e.g. assert().
